### PR TITLE
bugfix-https-google-font

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,4 +1,4 @@
-@import url('http://fonts.googleapis.com/css?family=Noto+Serif:400,700,400italic|Roboto+Condensed:400,300,700');
+@import url('fonts.googleapis.com/css?family=Noto+Serif:400,700,400italic|Roboto+Condensed:400,300,700');
 @import url('font-awesome.css');
 /* ==== overwrite bootstrap standard ==== */
 @import url('overwrite.css');


### PR DESCRIPTION
Fixed as per https://www.amixa.com/blog/2012/06/06/how-to-use-google-fonts-under-both-ssl-and-non-ssl-without-ssl-insecure-messages/